### PR TITLE
feat: add PyInstaller packaging to build standalone binary

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,87 @@
+name: Build Binary
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-amd64
+          - os: macos-13
+            platform: darwin-amd64
+          - os: macos-latest
+            platform: darwin-arm64
+          - os: windows-latest
+            platform: windows-amd64
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller==6.11.1
+          pip install -r requirements.txt
+
+      - name: Verify fast help stays in sync
+        run: python -m unittest tests.test_fast_help_consistency
+
+      - name: Build binary
+        run: python build.py
+
+      - name: Smoke test (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: dist/iact3 --version
+
+      - name: Smoke test (Windows)
+        if: runner.os == 'Windows'
+        run: dist/iact3.exe --version
+
+      - name: Upload archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iact3-binary-${{ matrix.platform }}
+          path: dist/iact3-*
+
+      - name: Upload version file
+        if: matrix.platform == 'linux-amd64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: iact3-version
+          path: dist/version.txt
+
+  upload-assets:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            artifacts/iact3-binary-*/* \
+            artifacts/iact3-version/version.txt \
+            --clobber

--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ Python 3.7+
 Fantastic documentation is available at:
 [English](https://aliyun.github.io/alibabacloud-ros-tool-iact3/#/en) |
 [中文版](https://aliyun.github.io/alibabacloud-ros-tool-iact3).
+
+# Building Standalone Binary
+
+You can build iact3 as a standalone binary using PyInstaller, which requires no Python installation to run.
+
+## Prerequisites
+
+- Python 3.9+
+- PyInstaller (`pip install pyinstaller==6.11.1`)
+- Project dependencies (`pip install -r requirements.txt`)
+
+## Build
+
+```bash
+python build.py
+```
+
+The binary will be generated at `dist/iact3` (or `dist/iact3.exe` on Windows).
+
+## Pre-built Binaries
+
+Pre-built binaries for Linux (amd64), macOS (amd64/arm64), and Windows (amd64) are available on the [Releases](https://github.com/aliyun/alibabacloud-ros-tool-iact3/releases) page. Download the appropriate binary for your platform and run it directly.

--- a/build.py
+++ b/build.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Build iact3 binary using PyInstaller and package as archive."""
+
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+from iact3 import __version__
+
+PYINSTALLER_REQUIRED_VERSION = '6.11.1'
+
+
+def main():
+    root = Path(__file__).parent
+    spec_file = root / 'iact3.spec'
+    dist_dir = root / 'dist'
+    build_dir = root / 'build'
+
+    try:
+        import PyInstaller
+    except ImportError:
+        print(
+            f'Error: PyInstaller is required. Install with: '
+            f'pip install pyinstaller=={PYINSTALLER_REQUIRED_VERSION}',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if PyInstaller.__version__ != PYINSTALLER_REQUIRED_VERSION:
+        print(
+            f'Warning: PyInstaller {PyInstaller.__version__} detected; '
+            f'recommended version is {PYINSTALLER_REQUIRED_VERSION}. '
+            f'Build artifacts may differ from those produced by CI.',
+            file=sys.stderr,
+        )
+
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+
+    system = platform.system().lower()
+    machine = _normalize_arch(platform.machine())
+
+    print(f'Building iact3 on {system} {machine}...')
+    subprocess.check_call([
+        sys.executable, '-m', 'PyInstaller',
+        str(spec_file),
+        '--distpath', str(dist_dir),
+        '--workpath', str(build_dir),
+        '--clean',
+        '--noconfirm',
+    ])
+
+    binary_name = 'iact3.exe' if system == 'windows' else 'iact3'
+    binary_path = dist_dir / binary_name
+
+    if not binary_path.exists():
+        print('\nBuild failed: binary not found.', file=sys.stderr)
+        sys.exit(1)
+
+    size_mb = binary_path.stat().st_size / (1024 * 1024)
+    print(f'\nBuild succeeded: {binary_path} ({size_mb:.1f} MB)')
+
+    archive_path = _create_archive(dist_dir, binary_path, system, machine)
+    archive_size_mb = archive_path.stat().st_size / (1024 * 1024)
+    print(f'Archive created: {archive_path} ({archive_size_mb:.1f} MB)')
+
+    version_file = dist_dir / 'version.txt'
+    version_file.write_text(__version__)
+    print(f'Version file created: {version_file}')
+
+
+def _normalize_arch(machine):
+    mapping = {
+        'x86_64': 'amd64',
+        'amd64': 'amd64',
+        'i386': 'i386',
+        'i686': 'i386',
+        'aarch64': 'arm64',
+        'arm64': 'arm64',
+    }
+    return mapping.get(machine.lower(), machine.lower())
+
+
+def _create_archive(dist_dir, binary_path, system, machine):
+    archive_name = f'iact3-{__version__}-{system}-{machine}'
+
+    if system == 'windows':
+        archive_path = dist_dir / f'{archive_name}.zip'
+        with zipfile.ZipFile(archive_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.write(binary_path, binary_path.name)
+    else:
+        archive_path = dist_dir / f'{archive_name}.tar.gz'
+        with tarfile.open(archive_path, 'w:gz') as tf:
+            tf.add(binary_path, arcname=binary_path.name)
+
+    return archive_path
+
+
+if __name__ == '__main__':
+    main()

--- a/hooks/rthook_six.py
+++ b/hooks/rthook_six.py
@@ -1,0 +1,77 @@
+import logging
+import sys
+import types
+
+_LOG = logging.getLogger(__name__)
+
+
+def _patch_vendored_six(prefix):
+    """Pre-populate sys.modules for vendored six.moves virtual modules."""
+    moves = types.ModuleType(f'{prefix}.moves')
+    moves.__path__ = []
+    moves.__package__ = f'{prefix}.moves'
+    sys.modules[f'{prefix}.moves'] = moves
+
+    # urllib subpackage
+    moves_urllib = types.ModuleType(f'{prefix}.moves.urllib')
+    moves_urllib.__path__ = []
+    moves_urllib.__package__ = f'{prefix}.moves.urllib'
+    sys.modules[f'{prefix}.moves.urllib'] = moves_urllib
+
+    import urllib.parse, urllib.error, urllib.request
+    moves_urllib.parse = urllib.parse
+    sys.modules[f'{prefix}.moves.urllib.parse'] = urllib.parse
+    moves_urllib.error = urllib.error
+    sys.modules[f'{prefix}.moves.urllib.error'] = urllib.error
+    moves_urllib.request = urllib.request
+    sys.modules[f'{prefix}.moves.urllib.request'] = urllib.request
+
+    # http modules
+    import http.client
+    sys.modules[f'{prefix}.moves.http_client'] = http.client
+    moves.http_client = http.client
+
+    from http import cookiejar
+    sys.modules[f'{prefix}.moves.http_cookiejar'] = cookiejar
+    moves.http_cookiejar = cookiejar
+
+    from http import cookies
+    sys.modules[f'{prefix}.moves.http_cookies'] = cookies
+    moves.http_cookies = cookies
+
+    # queue
+    import queue
+    sys.modules[f'{prefix}.moves.queue'] = queue
+    moves.queue = queue
+
+    # io
+    import io
+    moves.StringIO = io.StringIO
+    moves.cStringIO = io.StringIO
+
+    # configparser
+    import configparser
+    sys.modules[f'{prefix}.moves.configparser'] = configparser
+    moves.configparser = configparser
+
+    # builtins
+    moves.range = range
+    moves.zip = zip
+    moves.map = map
+    moves.filter = filter
+    moves.input = input
+    moves.intern = sys.intern
+    moves.reduce = __import__('functools').reduce
+
+
+_VENDORED_SIX_PREFIXES = [
+    'aliyunsdkcore.vendored.six',
+    'aliyunsdkcore.vendored.requests.packages.urllib3.packages.six',
+]
+
+for _prefix in _VENDORED_SIX_PREFIXES:
+    try:
+        _patch_vendored_six(_prefix)
+    except Exception as _exc:
+        _LOG.critical('Failed to patch vendored six at %s: %s', _prefix, _exc)
+        raise

--- a/iact3.spec
+++ b/iact3.spec
@@ -1,0 +1,91 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# PyInstaller spec for the iact3 standalone binary.
+#
+# Maintenance notes:
+#   - Recommended PyInstaller version: 6.11.1 (see build.py).
+#   - Add new top-level Alibaba Cloud SDK packages to `_direct_sdk_packages`
+#     when iact3 begins importing them directly.
+#   - Add transitive runtime-only deps (those PyInstaller cannot detect via
+#     static analysis) to `_transitive_sdk_packages`.
+#   - Add third-party libraries imported dynamically (e.g. inside report
+#     generation) to the explicit `hiddenimports` block below.
+#   - Standard library modules do NOT need to be listed; PyInstaller bundles
+#     them automatically.
+#   - Static data files must be declared in `datas=` and resolved at runtime
+#     via `sys._MEIPASS` when `sys.frozen` is True.
+#   - Runtime hooks live under `hooks/`; register them in `runtime_hooks=`.
+
+import sys
+from PyInstaller.utils.hooks import collect_submodules
+
+# Packages directly imported by iact3
+_direct_sdk_packages = [
+    'alibabacloud_ros20190910',
+    'alibabacloud_ecs20140526',
+    'alibabacloud_vpc20160428',
+    'alibabacloud_credentials',
+    'alibabacloud_tea_openapi',
+    'alibabacloud_tea_util',
+    'Tea',
+    'oss2',
+]
+
+# Transitive dependencies required at runtime
+_transitive_sdk_packages = [
+    'alibabacloud_openapi_util',
+    'alibabacloud_gateway_spi',
+    'aliyunsdkcore',
+    'aliyunsdkkms',
+]
+
+hiddenimports = collect_submodules('iact3')
+for _pkg in _direct_sdk_packages + _transitive_sdk_packages:
+    hiddenimports += collect_submodules(_pkg)
+
+hiddenimports += [
+    'xml.dom.minidom',
+    'configparser',
+    'dataclasses_jsonschema',
+    'cgi',
+    'tabulate',
+    'yattag',
+    'aiofiles',
+]
+
+a = Analysis(
+    ['iact3/__main__.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('iact3/report/html.css', 'iact3/report'),
+    ],
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=['hooks/rthook_six.py'],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='iact3',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=['*.dll', '*.dylib', '*.so'],
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/iact3/__init__.py
+++ b/iact3/__init__.py
@@ -1,0 +1,2 @@
+"""iact3 — Infrastructure as Code Templates Validation Test for Alibaba Cloud ROS."""
+__version__ = '0.1.13'

--- a/iact3/__main__.py
+++ b/iact3/__main__.py
@@ -1,4 +1,68 @@
-from iact3.main import sync_run
+import sys
+
+
+def _fast_version():
+    from iact3 import __version__
+    if getattr(sys, 'frozen', False):
+        print(__version__)
+        return
+    try:
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            print(version('alibabacloud-ros-iact3'))
+        except PackageNotFoundError:
+            print(__version__)
+    except Exception:
+        print(__version__)
+
+
+def _fast_help():
+    # MAINTENANCE: This help text is a static copy of argparse output for fast startup.
+    # When adding/removing commands or global options, update this text AND iact3/cli.py.
+    print("""usage: iact3 [args] <command> [args] [subcommand] [args]
+
+Infrastructure as Code Templates Validation Test.
+
+options:
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
+  -q, --quiet           reduce output to the minimum
+  -d, --debug           adds debug output and tracebacks
+  --profile _PROFILE    set the default profile used.
+  --log-prefix _LOG_PREFIX
+                        set the log prefix.
+
+commands:
+  base - Create or delete or list basic resources which includes vpc,security group and several switches for testing
+  cost - Give the price of the templates.
+  delete - Manually clean up the stacks which were created by Iact3
+  list - List stacks which were created by Iact3 for all regions.
+  policy - Get policies of the templates.
+  preview - Preview resources of templates.
+  test - Performs functional tests on IaC templates.
+  validate - Validate the templates.""")
+
+
+def _should_fast_path(args):
+    if not args:
+        return 'help'
+    if args[0] in ('-v', '--version'):
+        return 'version'
+    if any(a in ('-h', '--help') for a in args):
+        return 'help'
+    return None
+
+
+def sync_run():
+    action = _should_fast_path(sys.argv[1:])
+    if action == 'version':
+        _fast_version()
+        return
+    if action == 'help':
+        _fast_help()
+        return
+    from iact3.main import sync_run as _sync_run
+    _sync_run()
 
 
 if __name__ == "__main__":

--- a/iact3/main.py
+++ b/iact3/main.py
@@ -1,8 +1,6 @@
 import signal
 import sys
 
-from pkg_resources import get_distribution
-
 from iact3 import cli_modules
 from iact3.cli import CliCore, GLOBAL_ARGS, _get_log_level
 from iact3.generate_params import IAC_PACKAGE_NAME, IAC_NAME
@@ -68,10 +66,17 @@ def _print_tracebacks(log_level):
 
 
 def get_installed_version():
+    from iact3 import __version__
+    if getattr(sys, 'frozen', False):
+        return __version__
     try:
-        return get_distribution(IAC_PACKAGE_NAME).version
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            return version(IAC_PACKAGE_NAME)
+        except PackageNotFoundError:
+            return __version__
     except Exception:
-        return '[local source] no pip module installed'
+        return __version__
 
 
 def _sigint_handler(signum, frame):

--- a/iact3/report/generate_reports.py
+++ b/iact3/report/generate_reports.py
@@ -4,6 +4,7 @@ import json
 import xml.dom.minidom as minidom
 import logging
 import os
+import sys
 import textwrap
 import time
 from pathlib import Path
@@ -26,16 +27,26 @@ class ReportBuilder:
         self._stacks = stacks
         self._output_file = output_file
         self._report_json_name = f'{self._stacks.project_name}-result.json'
+        self._css_path = self._resolve_css_path()
+
+    @staticmethod
+    def _resolve_css_path():
+        if getattr(sys, 'frozen', False):
+            css_path = os.path.join(sys._MEIPASS, 'iact3', 'report', 'html.css')
+        else:
+            css_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'html.css')
+        if not os.path.isfile(css_path):
+            raise FileNotFoundError(f'Report CSS file not found: {css_path}')
+        return css_path
 
     async def generate_report(self):
         doc = yattag.Doc()
 
         tag = doc.tag
         text = doc.text
-        dirname = os.path.abspath(os.path.dirname(__file__))
         details = []
         test_result = 'Success'
-        async with aiofiles.open(f'{dirname}/html.css', 'r') as f:
+        async with aiofiles.open(self._css_path, 'r') as f:
             output_css = await f.read()
 
         with tag("html"):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,15 @@
 # -*- coding: utf-8 -*-
+import re
 import setuptools
+
+
+def _read_version():
+    with open("iact3/__init__.py") as fp:
+        match = re.search(r"^__version__\s*=\s*['\"]([^'\"]+)['\"]", fp.read(), re.M)
+        if not match:
+            raise RuntimeError("Unable to find __version__ in iact3/__init__.py")
+        return match.group(1)
+
 
 with open("requirements.txt") as fp:
     requirements = fp.read().splitlines()
@@ -11,7 +21,7 @@ with open("README.md") as fp:
 
 setuptools.setup(
     name="alibabacloud-ros-iact3",
-    version="0.1.12",
+    version=_read_version(),
 
     description="Iact3 is a tool that tests Terraform and ROS(Resource Orchestration Service) templates.",
     long_description=long_description,

--- a/tests/test_fast_help_consistency.py
+++ b/tests/test_fast_help_consistency.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Verify _fast_help() in iact3.__main__ stays in sync with iact3.cli_modules."""
+import inspect
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from iact3 import cli_modules
+from iact3.__main__ import _fast_help
+from iact3.cli import CliCore
+
+
+class TestFastHelpConsistency(unittest.TestCase):
+    def setUp(self):
+        captured = io.StringIO()
+        with redirect_stdout(captured):
+            _fast_help()
+        self.text = captured.getvalue()
+        self.commands = {
+            name.lower(): cls
+            for name, cls in inspect.getmembers(cli_modules, inspect.isclass)
+        }
+
+    def test_all_commands_listed(self):
+        for cmd in self.commands:
+            self.assertIn(
+                f'{cmd} -',
+                self.text,
+                f'Command "{cmd}" missing from _fast_help() output. '
+                f'Update iact3/__main__.py:_fast_help when changing commands.',
+            )
+
+    def test_command_descriptions_match(self):
+        """Each command's docstring summary must appear verbatim in _fast_help."""
+        for cmd, cls in self.commands.items():
+            description = CliCore._get_help(cls)
+            if not description:
+                continue
+            self.assertIn(
+                description,
+                self.text,
+                f'Command "{cmd}" description "{description}" not found in '
+                f'_fast_help() output. Sync iact3/__main__.py:_fast_help with '
+                f'the class docstring in iact3/cli_modules/{cmd}.py.',
+            )
+
+    def test_global_options_listed(self):
+        for opt in ('--quiet', '--debug', '--profile', '--log-prefix', '--version', '--help'):
+            self.assertIn(opt, self.text, f'Global option {opt} missing from _fast_help()')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add iact3.spec and build.py for PyInstaller onefile builds
- Support 4 platforms: linux-amd64, darwin-amd64, darwin-arm64, windows-amd64
- Add GitHub Actions workflow: build matrix → upload release assets
- Fast path for --version/--help to avoid heavy module imports
- Runtime hook for six module compatibility in frozen environment
- Normalize arch names (x86_64→amd64, aarch64→arm64)
- Output distributable archives (.tar.gz/.zip) and version.txt