### PR TITLE
ci: align version.txt with release tag

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Build binary
         run: python build.py
 
+      - name: Override version.txt with release tag
+        if: matrix.platform == 'linux-amd64' && github.event_name == 'release'
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          printf '%s' "${tag#v}" > dist/version.txt
+
       - name: Smoke test (Linux/macOS)
         if: runner.os != 'Windows'
         run: dist/iact3 --version


### PR DESCRIPTION
Override dist/version.txt with the release tag (stripped of leading "v") on release events so the published version file matches the tag instead of the hardcoded __version__ in iact3/__init__.py.