### PR TITLE
ci: align archive name with release tag via IACT3_BUILD_VERSION

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -36,14 +36,21 @@ jobs:
       - name: Verify fast help stays in sync
         run: python -m unittest tests.test_fast_help_consistency
 
-      - name: Build binary
-        run: python build.py
-
-      - name: Override version.txt with release tag
-        if: matrix.platform == 'linux-amd64' && github.event_name == 'release'
+      - name: Resolve build version
+        id: build_version
+        shell: bash
         run: |
-          tag="${{ github.event.release.tag_name }}"
-          printf '%s' "${tag#v}" > dist/version.txt
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+            echo "value=${tag#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build binary
+        env:
+          IACT3_BUILD_VERSION: ${{ steps.build_version.outputs.value }}
+        run: python build.py
 
       - name: Smoke test (Linux/macOS)
         if: runner.os != 'Windows'

--- a/build.py
+++ b/build.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Build iact3 binary using PyInstaller and package as archive."""
 
+import os
 import platform
 import shutil
 import subprocess
@@ -13,6 +14,7 @@ from pathlib import Path
 from iact3 import __version__
 
 PYINSTALLER_REQUIRED_VERSION = '6.11.1'
+BUILD_VERSION = os.environ.get('IACT3_BUILD_VERSION', '').strip() or __version__
 
 
 def main():
@@ -72,7 +74,7 @@ def main():
     print(f'Archive created: {archive_path} ({archive_size_mb:.1f} MB)')
 
     version_file = dist_dir / 'version.txt'
-    version_file.write_text(__version__)
+    version_file.write_text(BUILD_VERSION)
     print(f'Version file created: {version_file}')
 
 
@@ -89,7 +91,7 @@ def _normalize_arch(machine):
 
 
 def _create_archive(dist_dir, binary_path, system, machine):
-    archive_name = f'iact3-{__version__}-{system}-{machine}'
+    archive_name = f'iact3-{BUILD_VERSION}-{system}-{machine}'
 
     if system == 'windows':
         archive_path = dist_dir / f'{archive_name}.zip'


### PR DESCRIPTION
build.py now reads IACT3_BUILD_VERSION from the environment (falling back to __version__), and uses it for both the archive name and version.txt so both stay in sync. The workflow sets this env var to the release tag (sans leading "v") on release events; manual runs keep using the source version. This replaces the prior step that only overrode version.txt.