### PR TITLE
feat: PyInstaller packaging + ALIBABA_CLOUD_IACT3_COMPAT_MODE prefix

### DIFF
--- a/iact3/__init__.py
+++ b/iact3/__init__.py
@@ -1,2 +1,2 @@
 """iact3 — Infrastructure as Code Templates Validation Test for Alibaba Cloud ROS."""
-__version__ = '0.1.13'
+__version__ = '0.1.14'

--- a/iact3/__main__.py
+++ b/iact3/__main__.py
@@ -19,7 +19,9 @@ def _fast_version():
 def _fast_help():
     # MAINTENANCE: This help text is a static copy of argparse output for fast startup.
     # When adding/removing commands or global options, update this text AND iact3/cli.py.
-    print("""usage: iact3 [args] <command> [args] [subcommand] [args]
+    from iact3.util import get_program_name
+    prog = get_program_name('iact3')
+    print(f"""usage: {prog} [args] <command> [args] [subcommand] [args]
 
 Infrastructure as Code Templates Validation Test.
 

--- a/iact3/cli.py
+++ b/iact3/cli.py
@@ -229,6 +229,7 @@ class CliCore:
 
     def _build_parser(self, description, version):
         parser = CustomParser(
+            prog=self.name,
             description=description,
             usage=self._build_usage(),
             formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/iact3/main.py
+++ b/iact3/main.py
@@ -5,7 +5,7 @@ from iact3 import cli_modules
 from iact3.cli import CliCore, GLOBAL_ARGS, _get_log_level
 from iact3.generate_params import IAC_PACKAGE_NAME, IAC_NAME
 from iact3.logger import init_cli_logger
-from iact3.util import exit_with_code
+from iact3.util import exit_with_code, get_program_name
 
 LOG = init_cli_logger(loglevel="ERROR")
 DESCRIPTION = 'Infrastructure as Code Templates Validation Test.'
@@ -37,7 +37,7 @@ async def run():
         args.append('-h')
     try:
         version = get_installed_version()
-        cli = CliCore(IAC_NAME, cli_modules, DESCRIPTION, version, GLOBAL_ARGS.ARGS)
+        cli = CliCore(get_program_name(IAC_NAME), cli_modules, DESCRIPTION, version, GLOBAL_ARGS.ARGS)
         cli.parse(args)
         _default_profile = cli.parsed_args.__dict__.get('_profile')
         if _default_profile:

--- a/iact3/util.py
+++ b/iact3/util.py
@@ -19,7 +19,7 @@ def exit_with_code(code, msg=""):
 
 
 def get_program_name(base_name: str = 'iact3') -> str:
-    prefix = os.environ.get('ALIBABA_CLOUD_CMS_COMPAT_MODE', '').strip()
+    prefix = os.environ.get('ALIBABA_CLOUD_IACT3_COMPAT_MODE', '').strip()
     return f'{prefix} {base_name}' if prefix else base_name
 
 

--- a/iact3/util.py
+++ b/iact3/util.py
@@ -18,6 +18,11 @@ def exit_with_code(code, msg=""):
     sys.exit(code)
 
 
+def get_program_name(base_name: str = 'iact3') -> str:
+    prefix = os.environ.get('ALIBABA_CLOUD_CMS_COMPAT_MODE', '').strip()
+    return f'{prefix} {base_name}' if prefix else base_name
+
+
 def make_dir(path, ignore_exists=True):
     path = os.path.abspath(path)
     if ignore_exists and os.path.isdir(path):


### PR DESCRIPTION
## Summary
- Add PyInstaller packaging to ship iact3 as a standalone binary (build script, spec, runtime hook, CI workflow, README notes).
- Align packaged version / archive name with the release tag via `IACT3_BUILD_VERSION`.
- Add `ALIBABA_CLOUD_IACT3_COMPAT_MODE` env var: its value is used as a command prefix in usage / help / error output. e.g. `ALIBABA_CLOUD_IACT3_COMPAT_MODE=aliyun` → `usage: aliyun iact3 [args] <command> ...`. Applies to both the fast `--help` path and the dynamic argparse parser (including subcommand usage and error lines).
- Bump version to `0.1.14`.

## Test plan
- [x] `iact3 --help` shows `usage: iact3 [args] ...` when env unset
- [x] `ALIBABA_CLOUD_IACT3_COMPAT_MODE=aliyun iact3 --help` shows `usage: aliyun iact3 [args] ...`
- [x] `ALIBABA_CLOUD_IACT3_COMPAT_MODE=aliyun iact3 bogus` error line and usage both carry the `aliyun` prefix
- [x] `ALIBABA_CLOUD_IACT3_COMPAT_MODE=aliyun iact3 test -h` subcommand usage carries the prefix
- [x] `python -m unittest tests.test_fast_help_consistency` passes
- [x] CI build-binary workflow produces a standalone binary archive named with the release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)